### PR TITLE
Removed V2 Format

### DIFF
--- a/pthapi.py
+++ b/pthapi.py
@@ -47,10 +47,6 @@ formats = {
         'format' : 'MP3',
         'encoding' : '320'
     },
-    'V2': {
-        'format' : 'MP3', 
-        'encoding' : 'V2 (VBR)'
-    },
 }
 
 def allowed_transcodes(torrent):

--- a/pthbetter
+++ b/pthbetter
@@ -74,7 +74,7 @@ def main():
         config.set('passtheheadphones', 'data_dir', '')
         config.set('passtheheadphones', 'output_dir', '')
         config.set('passtheheadphones', 'torrent_dir', '')
-        config.set('passtheheadphones', 'formats', 'flac, v0, 320, v2')
+        config.set('passtheheadphones', 'formats', 'flac, v0, 320')
         config.set('passtheheadphones', 'media', ', '.join(pthapi.lossless_media))
         config.write(open(args.config, 'w'))
         print 'Please edit the configuration file: %s' % args.config

--- a/transcode.py
+++ b/transcode.py
@@ -17,7 +17,6 @@ import tagging
 encoders = {
     '320':  {'enc': 'lame', 'ext': '.mp3',  'opts': '-h -b 320 --ignore-tag-errors'},
     'V0':   {'enc': 'lame', 'ext': '.mp3',  'opts': '-V 0 --vbr-new --ignore-tag-errors'},
-    'V2':   {'enc': 'lame', 'ext': '.mp3',  'opts': '-V 2 --vbr-new --ignore-tag-errors'},
     'FLAC': {'enc': 'flac', 'ext': '.flac', 'opts': '--best'}
 }
 


### PR DESCRIPTION
https://passtheheadphones.me/forums.php?action=viewthread&threadid=1964
Since pthbetter is only meant for transcoding FLAC to MP3, V0 is always available.