### PR TITLE
pthapi: Changing tracker url

### DIFF
--- a/pthapi.py
+++ b/pthapi.py
@@ -73,7 +73,7 @@ class PthAPI:
         self.passkey = None
         self.userid = None
         self.userclass = None
-        self.tracker = "https://please.passtheheadphones.me/"
+        self.tracker = "https://flacsfor.me/"
         self.last_request = time.time()
         self.rate_limit = 2.0 # seconds between requests
         self._login()


### PR DESCRIPTION
As per latest message on the blog, let's change the tracker URL to flacsfor.me